### PR TITLE
Fix confusing misuse of const modifier

### DIFF
--- a/src/MemoryManager.c
+++ b/src/MemoryManager.c
@@ -4,14 +4,12 @@ typedef struct MemoryManagerCDT {
 	char *nextAddress;
 } MemoryManagerCDT;
 
-MemoryManagerADT createMemoryManager(void *const restrict memoryForMemoryManager, void *const restrict managedMemory) {
-	MemoryManagerADT memoryManager = (MemoryManagerADT) memoryForMemoryManager;
-	memoryManager->nextAddress = managedMemory;
-
-	return memoryManager;
+MemoryManagerADT createMemoryManager(void * restrict memoryForMemoryManager, void * restrict managedMemory) {
+	((MemoryManagerADT)memoryForMemoryManager)->nextAddress = managedMemory;
+	return memoryForMemoryManager;
 }
 
-void *allocMemory(MemoryManagerADT const restrict memoryManager, const size_t memoryToAllocate) {
+void *allocMemory(MemoryManagerADT restrict memoryManager, size_t memoryToAllocate) {
 	char *allocation = memoryManager->nextAddress;
 
 	memoryManager->nextAddress += memoryToAllocate;

--- a/src/MemoryManager.c
+++ b/src/MemoryManager.c
@@ -4,8 +4,8 @@ typedef struct MemoryManagerCDT {
 	char *nextAddress;
 } MemoryManagerCDT;
 
-MemoryManagerADT createMemoryManager(void * restrict memoryForMemoryManager, void * restrict managedMemory) {
-	((MemoryManagerADT)memoryForMemoryManager)->nextAddress = managedMemory;
+MemoryManagerADT createMemoryManager(void *restrict memoryForMemoryManager, void *restrict managedMemory) {
+	((MemoryManagerADT) memoryForMemoryManager)->nextAddress = managedMemory;
 	return memoryForMemoryManager;
 }
 

--- a/src/include/MemoryManager.h
+++ b/src/include/MemoryManager.h
@@ -5,8 +5,8 @@
 
 typedef struct MemoryManagerCDT *MemoryManagerADT;
 
-MemoryManagerADT createMemoryManager(void *const restrict memoryForMemoryManager, void *const restrict managedMemory);
+MemoryManagerADT createMemoryManager(void *restrict memoryForMemoryManager, void *restrict managedMemory);
 
-void *allocMemory(MemoryManagerADT const restrict memoryManager, const size_t memoryToAllocate);
+void *allocMemory(MemoryManagerADT restrict memoryManager, size_t memoryToAllocate);
 
 #endif


### PR DESCRIPTION
- **fix: miss usage of const modifier**
- **fix: formatting**

## Description
Fixes misuse of const modifiers at MemoryManager functions.

## Checklist
- [x] Unit testing
- [ ] Documentation


## Notes
I didn't change post-* const at MemoryManagerTest file because external
macros are being called and in those cases, const covers the possibility
of them changing your local copy and consequently may affect the result
of other tests within that function.
